### PR TITLE
feat: fix compilation on linux

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -9,7 +9,7 @@ package v8go
 // #cgo CXXFLAGS: -fno-rtti -fpic -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include -I${SRCDIR}/deps/include/angle/include
 // #cgo LDFLAGS: -pthread -lv8
 // #cgo darwin LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64 -lEGL -lGLESv2
-// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux_x86_64
+// #cgo linux LDFLAGS: -L${SRCDIR}/deps/linux_x86_64 -lEGL -lGLESv2
 // #cgo windows LDFLAGS: -L${SRCDIR}/deps/windows_x86_64 -ldbghelp -lssp -lwinmm -lz -lEGL -lGLESv2
 import "C"
 

--- a/glv8.cc
+++ b/glv8.cc
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include "v8.h"
 #include <EGL/egl.h>
 #include <GLES2/gl2.h>
-#include "v8.h"
 using namespace v8;
 
 extern bool sonic_gl_error_check;


### PR DESCRIPTION
It seems that some of the header files declared duplicate symbols, and
the wrong definitions were being used based on the order of the includes.

By moving one include, I was able to ensure that the right versions
are tried by the compiler.

I also added necessary linker flags to include the EGL libraries on
Linux.

Signed-off-by: Chris Waldon <christopher.waldon.dev@gmail.com>